### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/0x0Dx/x/security/code-scanning/2](https://github.com/0x0Dx/x/security/code-scanning/2)

In general, this issue is fixed by adding an explicit `permissions:` block either at the workflow root (applies to all jobs) or on the specific job, granting only the scopes actually needed (usually `contents: read` for a simple build-and-test workflow). This prevents the job from inheriting broader default write permissions from the repository or organization.

For this specific workflow, the steps only require read access to the repository contents to check out the code and run Go tools. There is no indication that the workflow needs to write to the repository, PRs, or issues. The simplest, least-privilege fix is to add `permissions: contents: read` at the workflow root just under `name: Go` (or alternatively under `jobs: go:`). This will limit the `GITHUB_TOKEN` to read-only access to repository contents for this workflow. No additional imports, methods, or external libraries are needed.

Concretely:
- Edit `.github/workflows/go.yml`.
- Insert a `permissions:` block near the top, after line 1 (`name: Go`), like:
  ```yaml
  permissions:
    contents: read
  ```
- Leave all existing steps and configuration unchanged, preserving current functionality while constraining token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
