### PR TITLE
feat: add chat command for conversational code assistance

### DIFF
--- a/goreviewer/cmd/review.go
+++ b/goreviewer/cmd/review.go
@@ -196,3 +196,54 @@ func init() {
 	runCmd.Flags().BoolVar(&disableReview, "disable-review", false, "Only provide summary")
 	RootCmd.AddCommand(runCmd)
 }
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Chat with AI about code",
+	Long:  "Have a conversation with AI about code. Provide code via stdin or file, then ask questions.",
+	Args:  cobra.NoArgs,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		codeContent, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+
+		cfg := reviewer.Config{
+			Model:       model,
+			Temperature: temperature,
+			MaxTokens:   maxTokens,
+			Debug:       verbose,
+
+			LightModel:    lightModel,
+			HeavyModel:    heavyModel,
+			SystemMessage: systemMessage,
+			Language:      language,
+			OpenAIBaseURL: openAIBaseURL,
+		}
+
+		r := reviewer.New(cfg, nil)
+
+		fmt.Print("Your question: ")
+		var question string
+		fmt.Scanln(&question)
+
+		resp, err := r.Chat(context.Background(), reviewer.ChatRequest{
+			CodeContext: string(codeContent),
+			Message:     question,
+		})
+		if err != nil {
+			return fmt.Errorf("chat failed: %w", err)
+		}
+
+		fmt.Println(resp)
+		return nil
+	},
+}
+
+func init() {
+	chatCmd.Flags().StringVar(&lightModel, "light-model", "", "Model for chat")
+	chatCmd.Flags().StringVar(&heavyModel, "heavy-model", "", "Model for chat")
+	chatCmd.Flags().StringVar(&language, "language", "en-US", "Response language")
+	chatCmd.Flags().StringVar(&openAIBaseURL, "openai-base-url", "", "OpenAI base URL")
+	RootCmd.AddCommand(chatCmd)
+}

--- a/goreviewer/internal/reviewer/reviewer.go
+++ b/goreviewer/internal/reviewer/reviewer.go
@@ -236,6 +236,98 @@ func (r *Reviewer) RespondToReviewComment(ctx context.Context, req ReviewComment
 	return r.parseSimpleResponse(body)
 }
 
+func (r *Reviewer) selectModel(isHeavy bool) string {
+	if isHeavy {
+		model := r.cfg.HeavyModel
+		if model == "" {
+			model = r.cfg.Model
+		}
+		if model == "" {
+			model = defaultModel
+		}
+		return model
+	}
+	model := r.cfg.LightModel
+	if model == "" {
+		model = defaultModel
+	}
+	return model
+}
+
+// ChatRequest represents a chat request.
+type ChatRequest struct {
+	CodeContext string
+	Message     string
+	FilePath    string
+	Line        int
+}
+
+// Chat responds to a chat message about code context.
+func (r *Reviewer) Chat(ctx context.Context, req ChatRequest) (string, error) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("OPENAI_API_KEY")
+	}
+	if apiKey == "" {
+		return "", errors.New("missing API key")
+	}
+
+	model := r.selectModel(true)
+
+	prompt := r.buildChatPrompt(req)
+
+	repoFull := os.Getenv("REPO_FULL_NAME")
+	referer := fmt.Sprintf("https://github.com/%s", repoFull)
+
+	baseURL := r.cfg.OpenAIBaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	body, err := r.callAPI(ctx, apiKey, baseURL, referer, model, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	return r.parseSimpleResponse(body)
+}
+
+func (r *Reviewer) buildChatPrompt(req ChatRequest) string {
+	var b strings.Builder
+
+	systemMsg := r.cfg.SystemMessage
+	if systemMsg == "" {
+		systemMsg = `You are @goreviewer, a helpful AI assistant for code reviews.`
+	}
+
+	lang := r.cfg.Language
+	if lang == "" {
+		lang = defaultLanguage
+	}
+	systemMsg += fmt.Sprintf("\n\nYour entire response must be in the language with ISO code: %s", lang)
+
+	b.WriteString(systemMsg)
+	b.WriteString("\n\n")
+
+	if req.FilePath != "" {
+		b.WriteString(fmt.Sprintf("The user is asking about file: **%s**\n", req.FilePath))
+		if req.Line > 0 {
+			b.WriteString(fmt.Sprintf("Specifically about line: **%d**\n", req.Line))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Code context:\n\n")
+	b.WriteString("```\n")
+	b.WriteString(req.CodeContext)
+	b.WriteString("\n```\n\n")
+
+	b.WriteString(fmt.Sprintf("User's question: %s\n\n", req.Message))
+	b.WriteString("Please answer the user's question based on the provided code context. Be helpful and specific.")
+
+	return b.String()
+}
+
 func (r *Reviewer) buildReviewPrompt(diffContent string) string {
 	var b strings.Builder
 


### PR DESCRIPTION
## Summary
- Add `goreviewer chat` command for conversational interactions with AI about code
- Provides code via stdin, then type questions interactively
- Supports any OpenAI-compatible API endpoint

## Usage
```bash
# Chat about a file
cat file.go | goreviewer chat
# Or chat about a diff
git diff | goreviewer chat
```

The bot will ask for your question after receiving the code context.

## Changes
- Add `Chat` method in `internal/reviewer/reviewer.go`
- Add `chat` command in `cmd/review.go`
- Supports file path and line number context