### PR TITLE
fix: prevent duplicate review comments on PRs

### DIFF
--- a/goreviewer/cmd/review.go
+++ b/goreviewer/cmd/review.go
@@ -68,7 +68,7 @@ func NewReviewCmd() *cobra.Command {
 			}
 
 			if postToGitHub && ghClient != nil && prNumber > 0 && repoFullName != "" {
-				postReview(ghClient, result.Review, result.LabelsAdded, string(diffContent))
+				postReview(ghClient, result.Review, result.LabelsAdded)
 			}
 
 			fmt.Println(jsonOut)
@@ -90,11 +90,11 @@ func NewReviewCmd() *cobra.Command {
 	return cmd
 }
 
-func postReview(ghClient *github.Client, review string, labels []string, diff string) {
+func postReview(ghClient *github.Client, review string, labels []string) {
 	if ghClient == nil {
 		return
 	}
-	if err := ghClient.PostReview(context.Background(), review, diff); err != nil {
+	if err := ghClient.PostReview(context.Background(), review); err != nil {
 		fmt.Fprintln(os.Stderr, "Warning: failed to post review:", err)
 	}
 	for _, label := range labels {

--- a/goreviewer/cmd/run.go
+++ b/goreviewer/cmd/run.go
@@ -62,7 +62,7 @@ func NewRunCmd() *cobra.Command {
 			result, err := r.Review(context.Background(), string(diffContent))
 			if err != nil {
 				if ghClient != nil {
-					if err := ghClient.PostReview(context.Background(), result.Review, string(diffContent)); err != nil {
+					if err := ghClient.PostReview(context.Background(), result.Review); err != nil {
 						fmt.Fprintln(os.Stderr, "Warning: failed to post review:", err)
 					}
 				}
@@ -70,7 +70,7 @@ func NewRunCmd() *cobra.Command {
 			}
 
 			if ghClient != nil {
-				postReview(ghClient, result.Review, result.LabelsAdded, string(diffContent))
+				postReview(ghClient, result.Review, result.LabelsAdded)
 				_ = ghClient.RemoveLabel(context.Background(), "ai_code_review")
 			}
 

--- a/goreviewer/internal/github/client.go
+++ b/goreviewer/internal/github/client.go
@@ -3,8 +3,6 @@ package github
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
@@ -234,92 +232,13 @@ func (c *Client) fetchHumanComments(ctx context.Context) (string, error) {
 	return strings.Join(lines, "\n\n---\n\n"), nil
 }
 
-// PostReview posts a review comment to the PR. It checks for existing
-// AI review comments using diff hash and either skips (same diff),
-// or creates a new comment if the diff has changed.
-func (c *Client) PostReview(ctx context.Context, body, diff string) error {
-	diffHash := hashDiff(diff)
-
-	existingID, existingHash, err := c.FindExistingReview(ctx)
-	if err != nil {
-		return fmt.Errorf("find existing review: %w", err)
-	}
-
-	// Same diff - skip posting duplicate
-	if existingID != 0 && existingHash == diffHash {
-		return nil
-	}
-
-	// Add hash to comment body
-	if diffHash != "" {
-		hashComment := fmt.Sprintf("\n\n<!-- diffhash:%s -->", diffHash)
-		body += hashComment
-	}
-
-	// Create new comment (never update existing)
-	_, _, err = c.ghClient.Issues.CreateComment(ctx, c.owner, c.repo, c.prNumber, &github.IssueComment{
+// PostReview posts a new review comment to the PR.
+func (c *Client) PostReview(ctx context.Context, body string) error {
+	_, _, err := c.ghClient.Issues.CreateComment(ctx, c.owner, c.repo, c.prNumber, &github.IssueComment{
 		Body: &body,
 	})
 	if err != nil {
 		return fmt.Errorf("create comment: %w", err)
-	}
-
-	return nil
-}
-
-func hashDiff(diff string) string {
-	if diff == "" {
-		return ""
-	}
-	hash := sha256.Sum256([]byte(diff))
-	return hex.EncodeToString(hash[:])
-}
-
-// FindExistingReview looks for an existing AI Code Review comment.
-// Returns the comment ID, diff hash, and error if any.
-func (c *Client) FindExistingReview(ctx context.Context) (int64, string, error) {
-	comments, _, err := c.ghClient.Issues.ListComments(ctx, c.owner, c.repo, c.prNumber, nil)
-	if err != nil {
-		return 0, "", fmt.Errorf("list comments: %w", err)
-	}
-
-	for i := len(comments) - 1; i >= 0; i-- {
-		body := comments[i].GetBody()
-		if strings.HasPrefix(body, "## AI Code Review") {
-			hash := c.extractDiffHash(body)
-			return comments[i].GetID(), hash, nil
-		}
-	}
-
-	return 0, "", nil
-}
-
-func (c *Client) extractDiffHash(body string) string {
-	prefix := "<!-- diffhash:"
-	suffix := " -->"
-	start := strings.Index(body, prefix)
-	if start == -1 {
-		return ""
-	}
-	start += len(prefix)
-	end := strings.Index(body[start:], suffix)
-	if end == -1 {
-		return ""
-	}
-	return body[start : start+end]
-}
-
-// UpdateComment edits an existing comment.
-func (c *Client) UpdateComment(ctx context.Context, commentID int64, body, diffHash string) error {
-	if diffHash != "" {
-		hashComment := fmt.Sprintf("\n\n<!-- diffhash:%s -->", diffHash)
-		body += hashComment
-	}
-	_, _, err := c.ghClient.Issues.EditComment(ctx, c.owner, c.repo, commentID, &github.IssueComment{
-		Body: &body,
-	})
-	if err != nil {
-		return fmt.Errorf("edit comment: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Prevent duplicate AI Code Review comments by checking for existing reviews before posting
- If review content is identical to existing comment, skip posting (suppress duplicate)
- If review content has changed, update the existing comment instead of creating a new one

This fixes the issue where GoReviewer was posting multiple identical comments whenever new commits were pushed to a PR (#32).